### PR TITLE
Inhalt Abschnitt Technische Produktumgebung

### DIFF
--- a/Pflichtenheft.md
+++ b/Pflichtenheft.md
@@ -142,11 +142,31 @@ FRAGE: Bisher gab es keine Statuus für Kunden! Ist hier die Kundengruppe gemein
 
 # 9. Nichtfunktionale Anforderungen
 
-# 10. Technische Produktumgebung
+# Technische Produktumgebung
 
-- Software
+Dieses Kapitel beschreibt in welcher Umgebung das Programm laufen soll.
 
-- Hardware
+## Software ##
+
+Die Software wird für die folgende Softwareumgebung entwickelt:
+
+
+- Betriebssystem: Microsoft Windows 7 oder höher
+
+- .NET Framework 4.5
+ 
+
+## Hardware ##
+
+Die Software wird auf einem Computer mit den folgenden technischen Daten lauffähig sein:
+
+- Prozessor: 1 GHz oder schneller 
+
+- RAM: 2 GB
+
+- Festplattenspeicher: 20 GB 
+
+Zusätzliche Standardperipheriegeräte wie Maus, Tastatur und Monitor werden vorausgesetzt.
 
 - Orgware
 

--- a/Pflichtenheft.md
+++ b/Pflichtenheft.md
@@ -168,8 +168,8 @@ Die Software wird auf einem Computer mit den folgenden technischen Daten lauffä
 
 Zusätzliche Standardperipheriegeräte wie Maus, Tastatur und Monitor werden vorausgesetzt.
 
-- Orgware
+## Produktschnittstellen ##
 
-- Produktschnittstellen
+Keine externen Schnittstellen zu anderer Software geplant.
 
 # 11. spezielle Anforderungen an die Entwicklerumgebung


### PR DESCRIPTION
Habe etwas zu den Abschnitten Software- und Hardwareumgebung geschrieben, sowie Schnittstellen zu Drittsoftware ausgeschlossen.

Das Kapitel Orgware erscheint mir nicht klar abgrenzbar und wurde daher entfernt.
